### PR TITLE
Crear visor geoespacial de energía con Leaflet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,94 @@
-# EnrgiaCol
+# Visor Energético de Colombia
+
+Este repositorio contiene un visor web desarrollado con [Leaflet](https://leafletjs.com/) para explorar capas geoespaciales relacionadas con la infraestructura energética y condicionantes socioambientales de Colombia.
+
+## Características principales
+
+- **Subestaciones** y **red eléctrica** consultadas en tiempo real desde OpenStreetMap mediante la API de Overpass.
+- Capas locales configurables para representar:
+  - Máscara de pendiente de suelo.
+  - Áreas protegidas ambientales.
+  - Áreas sensibles por conflictos sociales.
+- Compatibilidad con servicios WMS adicionales.
+- Control de capas y ventana de estado para conocer el resultado de cada carga.
+- Diseño adaptable que funciona tanto en escritorio como en dispositivos móviles.
+
+## Requisitos
+
+No se necesita instalar dependencias. Basta con servir el directorio raíz mediante cualquier servidor web estático.
+
+## Uso
+
+1. Clona el repositorio:
+
+   ```bash
+   git clone https://github.com/<tu-usuario>/EnergiaCol.git
+   cd EnergiaCol
+   ```
+
+2. Inicia un servidor web sencillo (ejemplos):
+
+   ```bash
+   # Usando Python 3
+   python -m http.server 8000
+
+   # o utilizando Node.js con npx
+   npx serve .
+   ```
+
+3. Abre el navegador en `http://localhost:8000` (o el puerto que hayas elegido).
+
+El visor cargará automáticamente las capas definidas. Las capas provenientes de Overpass pueden tardar algunos segundos dependiendo de la disponibilidad del servicio y el tamaño de la respuesta.
+
+## Configuración de capas
+
+La configuración se encuentra en `assets/js/app.js`:
+
+- **Capas de Overpass (OSM)**: dentro del objeto `overpassEndpoints`. Ajusta la consulta, estilos o el límite espacial según tus necesidades.
+- **Capas locales/WMS**: en el arreglo `customLayersConfig`. Cada elemento admite los siguientes campos:
+
+  ```js
+  {
+    key: 'identificadorUnico',
+    name: 'Nombre visible en el control de capas',
+    source: 'geojson' | 'wms',
+    path: 'ruta/al/archivo.geojson', // requerido si source === 'geojson'
+    url: 'https://servidor/wms',     // requerido si source === 'wms'
+    options: {                       // opciones adicionales para L.tileLayer.wms
+      layers: 'nombre_capa',
+      format: 'image/png',
+      transparent: true,
+      attribution: 'Fuente',
+    },
+    style: { ... },                  // estilos para capas GeoJSON
+    visibleByDefault: true | false,
+  }
+  ```
+
+Los archivos GeoJSON de ejemplo ubicados en el directorio `data/` sirven como plantilla para sustituir por tus datos reales.
+
+## Estructura del proyecto
+
+```
+.
+├── assets
+│   ├── css
+│   │   └── style.css
+│   └── js
+│       └── app.js
+├── data
+│   ├── areas_protegidas.geojson
+│   ├── conflictos_sociales.geojson
+│   └── pendiente_suelo.geojson
+└── index.html
+```
+
+## Buenas prácticas y consideraciones
+
+- Respeta las condiciones de uso de la API de Overpass: evita consultas innecesarias y reutiliza los resultados cuando sea posible.
+- Si requieres un volumen de datos mayor o una disponibilidad garantizada, considera montar tus propios servicios geoespaciales (por ejemplo, GeoServer) y actualizar la configuración a servicios WMS/WMTS o vector tiles.
+- Para despliegues en producción se recomienda empaquetar los recursos estáticos y servirlos mediante un CDN o un servicio web dedicado.
+
+## Licencia
+
+Este proyecto se distribuye bajo la licencia MIT. Consulta el archivo `LICENSE` si decides añadir uno al repositorio. Los datos de OpenStreetMap se encuentran bajo la licencia [ODbL](https://opendatacommons.org/licenses/odbl/).

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,156 @@
+:root {
+  --primary: #0b3d91;
+  --secondary: #2c7fb8;
+  --accent: #fdae61;
+  --background: #f7f9fb;
+  --text: #1f2933;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: var(--text);
+  background-color: var(--background);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header,
+.app-footer {
+  background: linear-gradient(90deg, var(--primary), var(--secondary));
+  color: #ffffff;
+  padding: 1.5rem 2rem;
+  text-align: center;
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: clamp(1.8rem, 2.5vw, 2.4rem);
+}
+
+.app-header p {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.app-footer small {
+  font-size: 0.85rem;
+}
+
+.app-layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr);
+  gap: 1rem;
+  padding: 1rem 1.5rem 2rem;
+}
+
+.map-panel {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 20px 35px -20px rgba(11, 61, 145, 0.35);
+}
+
+#map {
+  width: 100%;
+  height: 100%;
+  min-height: 620px;
+}
+
+.info-panel {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 28px -18px rgba(31, 41, 51, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.info-panel h2,
+.info-panel h3 {
+  margin-top: 0;
+  color: var(--primary);
+}
+
+.layer-status ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.layer-status li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  border-left: 4px solid var(--secondary);
+  padding-left: 0.75rem;
+}
+
+.layer-status .status-icon {
+  font-size: 1rem;
+}
+
+.help ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.help li {
+  line-height: 1.5;
+}
+
+.leaflet-container a {
+  color: var(--primary);
+}
+
+@media (max-width: 960px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .info-panel {
+    order: -1;
+  }
+
+  #map {
+    min-height: 480px;
+  }
+}
+
+.popup-content {
+  font-size: 0.9rem;
+}
+
+.popup-content h3 {
+  margin: 0 0 0.25rem;
+  color: var(--primary);
+  font-size: 1rem;
+}
+
+.popup-content h4 {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.popup-content ul {
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.popup-content li {
+  margin-bottom: 0.35rem;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,295 @@
+const mapConfig = {
+  center: [4.5709, -74.2973],
+  zoom: 6,
+  minZoom: 5,
+  maxZoom: 14,
+};
+
+const colombiaBounds = L.latLngBounds(
+  L.latLng(-4.5, -79.1),
+  L.latLng(13.6, -66.8)
+);
+
+const colombiaBbox = [
+  colombiaBounds.getSouth(),
+  colombiaBounds.getWest(),
+  colombiaBounds.getNorth(),
+  colombiaBounds.getEast(),
+].join(',');
+
+const overpassEndpoints = {
+  subestaciones: {
+    label: 'Subestaciones (OSM)',
+    query: `[out:json][timeout:180];
+      (
+        node["power"="substation"](${colombiaBbox});
+        way["power"="substation"](${colombiaBbox});
+        relation["power"="substation"](${colombiaBbox});
+      );
+      out body center;`,
+    style: {
+      radius: 6,
+      fillColor: '#2c7fb8',
+      color: '#0b3d91',
+      weight: 1,
+      opacity: 1,
+      fillOpacity: 0.8,
+    },
+  },
+  redElectrica: {
+    label: 'Red eléctrica (OSM)',
+    query: `[out:json][timeout:180];
+      (
+        way["power"="line"](${colombiaBbox});
+        relation["power"="line"](${colombiaBbox});
+      );
+      out body;
+      >;
+      out skel qt;`,
+    style: {
+      color: '#fdae61',
+      weight: 2,
+      opacity: 0.85,
+    },
+  },
+};
+
+const customLayersConfig = [
+  {
+    key: 'slopeMask',
+    name: 'Máscara de pendiente de suelo',
+    source: 'geojson',
+    path: 'data/pendiente_suelo.geojson',
+    style: {
+      color: '#7fc97f',
+      weight: 1,
+      fillColor: '#b8e186',
+      fillOpacity: 0.35,
+    },
+    visibleByDefault: true,
+  },
+  {
+    key: 'protectedAreas',
+    name: 'Áreas protegidas ambientales',
+    source: 'geojson',
+    path: 'data/areas_protegidas.geojson',
+    style: {
+      color: '#386cb0',
+      weight: 1,
+      fillColor: '#8da0cb',
+      fillOpacity: 0.4,
+    },
+    visibleByDefault: false,
+  },
+  {
+    key: 'socialConflict',
+    name: 'Áreas sensibles por conflictos sociales',
+    source: 'geojson',
+    path: 'data/conflictos_sociales.geojson',
+    style: {
+      color: '#ef3b2c',
+      weight: 1,
+      fillColor: '#fb6a4a',
+      fillOpacity: 0.35,
+    },
+    visibleByDefault: false,
+  },
+  // Ejemplo de configuración para servicios WMS.
+  // Descomenta y ajusta para utilizar un servicio externo.
+  // {
+  //   key: 'wmsExample',
+  //   name: 'Ejemplo WMS',
+  //   source: 'wms',
+  //   url: 'https://tuservidor/wms',
+  //   options: {
+  //     layers: 'capa_wms',
+  //     format: 'image/png',
+  //     transparent: true,
+  //     attribution: 'Fuente WMS',
+  //   },
+  //   visibleByDefault: false,
+  // },
+];
+
+const statusList = document.getElementById('status-list');
+
+function updateStatus(message, status = 'loading') {
+  const icons = {
+    loading: '⏳',
+    success: '✅',
+    error: '⚠️',
+  };
+
+  const listItem = document.createElement('li');
+  listItem.innerHTML = `<span class="status-icon">${icons[status]}</span>${message}`;
+  statusList.appendChild(listItem);
+}
+
+function clearStatus() {
+  statusList.innerHTML = '';
+}
+
+function buildBaseLayers() {
+  const osmStandard = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  });
+
+  const cartoPositron = L.tileLayer(
+    'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+    {
+      maxZoom: 19,
+      attribution:
+        '&copy; <a href="https://carto.com/attributions">CARTO</a>, &copy; OpenStreetMap contributors',
+    }
+  );
+
+  return {
+    OpenStreetMap: osmStandard,
+    'CartoDB Positron': cartoPositron,
+  };
+}
+
+function buildMap() {
+  const baseLayers = buildBaseLayers();
+  const map = L.map('map', {
+    center: mapConfig.center,
+    zoom: mapConfig.zoom,
+    minZoom: mapConfig.minZoom,
+    maxZoom: mapConfig.maxZoom,
+    layers: [baseLayers.OpenStreetMap],
+    maxBounds: colombiaBounds.pad(0.2),
+    maxBoundsViscosity: 0.6,
+  });
+
+  L.control.scale({ metric: true }).addTo(map);
+
+  return { map, baseLayers };
+}
+
+async function fetchOverpassData(query) {
+  const overpassUrl = 'https://overpass-api.de/api/interpreter';
+  const response = await fetch(overpassUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `data=${encodeURIComponent(query)}`,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error en Overpass: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return osmtogeojson(data);
+}
+
+function createPopupContent(properties = {}, layerName) {
+  const title = properties.name || properties.ref || 'Elemento sin nombre';
+  const entries = Object.entries(properties)
+    .filter(([key]) => !['@id', 'name'].includes(key))
+    .map(([key, value]) => `<li><strong>${key}</strong>: ${value}</li>`)
+    .join('');
+
+  const listContent = entries || '<li>Sin atributos adicionales disponibles.</li>';
+
+  return `
+    <article class="popup-content">
+      <h3>${layerName}</h3>
+      <h4>${title}</h4>
+      <ul>${listContent}</ul>
+    </article>
+  `;
+}
+
+function setupGeoJsonLayer(geojson, options = {}) {
+  const { style = {}, pointToLayer, onEachFeature } = options;
+
+  return L.geoJSON(geojson, {
+    style,
+    pointToLayer:
+      pointToLayer || ((feature, latlng) => L.circleMarker(latlng, Object.assign({ radius: 6 }, style))),
+    onEachFeature,
+  });
+}
+
+async function addOverpassLayer(map, layerControl, layerKey, config) {
+  try {
+    updateStatus(`Cargando ${config.label} desde Overpass...`, 'loading');
+    const geojson = await fetchOverpassData(config.query);
+
+    const layer = setupGeoJsonLayer(geojson, {
+      style: config.style,
+      onEachFeature: (feature, layerItem) => {
+        const popupHtml = createPopupContent(feature.properties, config.label);
+        layerItem.bindPopup(popupHtml);
+      },
+    });
+
+    layer.addTo(map);
+    layerControl.addOverlay(layer, config.label);
+    updateStatus(
+      `${config.label} cargada (${geojson.features?.length ?? 0} elementos).`,
+      'success'
+    );
+  } catch (error) {
+    console.error(error);
+    updateStatus(`No se pudo cargar ${config.label}: ${error.message}`, 'error');
+  }
+}
+
+async function addCustomLayer(map, layerControl, config) {
+  try {
+    updateStatus(`Cargando ${config.name}...`, 'loading');
+    let layer;
+
+    if (config.source === 'geojson') {
+      const response = await fetch(config.path);
+      if (!response.ok) {
+        throw new Error(`Archivo no disponible (${response.status})`);
+      }
+
+      const geojson = await response.json();
+      layer = setupGeoJsonLayer(geojson, {
+        style: config.style,
+        onEachFeature: (feature, layerItem) => {
+          const popupHtml = createPopupContent(feature.properties, config.name);
+          layerItem.bindPopup(popupHtml);
+        },
+      });
+    } else if (config.source === 'wms') {
+      layer = L.tileLayer.wms(config.url, config.options);
+    } else {
+      throw new Error(`Fuente desconocida: ${config.source}`);
+    }
+
+    if (config.visibleByDefault) {
+      layer.addTo(map);
+    }
+
+    layerControl.addOverlay(layer, config.name);
+    updateStatus(`${config.name} disponible.`, 'success');
+  } catch (error) {
+    console.error(error);
+    updateStatus(`No se pudo cargar ${config.name}: ${error.message}`, 'error');
+  }
+}
+
+async function init() {
+  clearStatus();
+
+  const { map, baseLayers } = buildMap();
+  const layerControl = L.control.layers(baseLayers, {}, { collapsed: false }).addTo(map);
+
+  // Capas OSM (Overpass)
+  for (const [layerKey, config] of Object.entries(overpassEndpoints)) {
+    await addOverpassLayer(map, layerControl, layerKey, config);
+  }
+
+  // Capas locales o WMS
+  for (const config of customLayersConfig) {
+    await addCustomLayer(map, layerControl, config);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/data/areas_protegidas.geojson
+++ b/data/areas_protegidas.geojson
@@ -1,0 +1,46 @@
+{
+  "type": "FeatureCollection",
+  "name": "areas_protegidas",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "nombre": "Parque Nacional Natural Amacayacu",
+        "categoria": "Parque Nacional",
+        "fuente": "Parques Nacionales"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-70.25, -3.8],
+            [-69.6, -3.8],
+            [-69.6, -3.2],
+            [-70.25, -3.2],
+            [-70.25, -3.8]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "nombre": "Santuario de Flora y Fauna Otún Quimbaya",
+        "categoria": "Santuario de Flora y Fauna",
+        "fuente": "Parques Nacionales"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-75.6, 4.6],
+            [-75.45, 4.6],
+            [-75.45, 4.8],
+            [-75.6, 4.8],
+            [-75.6, 4.6]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/data/conflictos_sociales.geojson
+++ b/data/conflictos_sociales.geojson
@@ -1,0 +1,46 @@
+{
+  "type": "FeatureCollection",
+  "name": "conflictos_sociales",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "nombre": "Zona de consulta previa",
+        "tipo_conflicto": "Comunidades indígenas",
+        "estado": "En diálogo"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-73.9, 2.3],
+            [-73.4, 2.3],
+            [-73.4, 2.8],
+            [-73.9, 2.8],
+            [-73.9, 2.3]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "nombre": "Área con conflictos socioambientales",
+        "tipo_conflicto": "Reasentamiento",
+        "estado": "Seguimiento"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-74.8, 9.3],
+            [-74.3, 9.3],
+            [-74.3, 9.7],
+            [-74.8, 9.7],
+            [-74.8, 9.3]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/data/pendiente_suelo.geojson
+++ b/data/pendiente_suelo.geojson
@@ -1,0 +1,44 @@
+{
+  "type": "FeatureCollection",
+  "name": "pendiente_suelo",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "categoria": "Pendiente alta",
+        "rango_grados": ">30"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-75.8, 4.7],
+            [-75.2, 4.7],
+            [-75.2, 5.1],
+            [-75.8, 5.1],
+            [-75.8, 4.7]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "categoria": "Pendiente media",
+        "rango_grados": "15-30"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-73.4, 6.1],
+            [-72.8, 6.1],
+            [-72.8, 6.6],
+            [-73.4, 6.6],
+            [-73.4, 6.1]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Visor Energético de Colombia</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-o9N1j7kPBi0hA6kz+oTX0bAd/8erFScsZdP4tF+4Wj0="
+      crossorigin=""
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Visor de Datos Energéticos de Colombia</h1>
+      <p>
+        Visualiza la infraestructura eléctrica y capas ambientales clave para
+        la planeación energética del país.
+      </p>
+    </header>
+
+    <main class="app-layout">
+      <section class="map-panel">
+        <div id="map"></div>
+      </section>
+      <aside class="info-panel">
+        <section>
+          <h2>Capas disponibles</h2>
+          <p>
+            Utiliza el control de capas en la esquina superior derecha del mapa
+            para activar o desactivar la información que necesites.
+          </p>
+        </section>
+        <section class="layer-status" id="layer-status">
+          <h3>Estado de carga</h3>
+          <ul id="status-list"></ul>
+        </section>
+        <section class="help">
+          <h2>Instrucciones</h2>
+          <ol>
+            <li>
+              <strong>Subestaciones</strong> y <strong>Red eléctrica</strong> se
+              consultan dinámicamente desde OpenStreetMap mediante la API de
+              Overpass.
+            </li>
+            <li>
+              Las demás capas se cargan desde archivos GeoJSON locales o
+              servicios WMS configurables en
+              <code>assets/js/app.js</code>.
+            </li>
+            <li>
+              Puedes adaptar la configuración de fuentes de datos según tus
+              necesidades sin modificar la estructura general del visor.
+            </li>
+          </ol>
+        </section>
+      </aside>
+    </main>
+
+    <footer class="app-footer">
+      <small>
+        Datos de OpenStreetMap disponibles bajo la licencia ODbL. Capas
+        adicionales provienen de fuentes locales o institucionales.
+      </small>
+    </footer>
+
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-SmHgwlHcCbto2HjSAGAj4Tk0m6tcwBfHfM5Z8Hf7kL8="
+      crossorigin=""
+    ></script>
+    <script src="https://unpkg.com/osmtogeojson@3.0.0/osmtogeojson.js"></script>
+    <script src="assets/js/app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- montar una interfaz web con Leaflet y un panel informativo para consultar capas energéticas de Colombia
- consumir subestaciones y red eléctrica desde Overpass/OpenStreetMap y permitir configurar capas locales o WMS
- añadir ejemplos GeoJSON para capas ambientales y sociales junto con documentación de uso y configuración

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd7dd269048324931e96f2f47a5520